### PR TITLE
Adding more spawner and buffer passenger configs.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,9 +66,13 @@ default[:passenger][:pool_idle_time] = 300
 default[:passenger][:max_requests] = 0
 default[:passenger][:gem_binary] = nil
 default[:passenger][:spawner_idle_time] = 0
+default[:passenger][:rails_framework_spawner_idle_time] = 0
+default[:passenger][:rails_app_spawner_idle_time] = 0
 default[:passenger][:default_user] = nil
 default[:passenger][:default_group] = nil
 default[:passenger][:log_level] = 0
 default[:passenger][:friendly_error_pages] = nil
+default[:passenger][:passenger_buffers] = '8 16k'
+default[:passenger][:passenger_buffer_size] = '32k'
 
 

--- a/templates/default/passenger.conf.erb
+++ b/templates/default/passenger.conf.erb
@@ -6,6 +6,8 @@ passenger_max_instances_per_app <%= @config[:max_instances_per_app] %>;
 passenger_max_pool_size <%= @config[:max_pool_size] %>;
 passenger_spawn_method <%= @config[:spawn_method] %>;
 passenger_pool_idle_time <%= @config[:pool_idle_time] %>;
+rails_framework_spawner_idle_time <%= @config[:rails_framework_spawner_idle_time] %>;
+rails_app_spawner_idle_time <%= @config[:rails_app_spawner_idle_time] %>;
 passenger_max_requests <%= @config[:max_requests] %>;
 passenger_log_level <%= @config[:log_level] %>;
 
@@ -21,3 +23,5 @@ passenger_default_group <%= @config[:default_group] %>;
 passenger_friendly_error_pages <%= @config[:friendly_error_pages] %>;
 <% end %>
 
+passenger_buffers <%= @config[:passenger_buffers] %>;
+passenger_buffer_size <%= @config[:passenger_buffer_size] %>;


### PR DESCRIPTION
Ensure that the Spawner process is kept around.
`rails_framework_spawner_idle_time 0;`

Ensure that the Application Spawners are kept around.
`rails_app_spawner_idle_time 0;`

Fixes Nginx large header issue.
`passenger_buffers 8 16k;`
`passenger_buffer_size 32k`
