### PR TITLE
Fixing try files bug in named location.

### DIFF
--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -81,7 +81,7 @@ server {
       break;
     }
   <% if @params[:try_static_files] %>
-    try_files  $uri $uri/index.html $uri.html @app_<%= @application_name %>;
+    try_files  $uri $uri/index.html $uri.html @app_<%= @application_name %>_ssl;
   }
   location @app_<%= @application_name %>_ssl {
   <% end %>


### PR DESCRIPTION
Fixing bug in SSL try files line that would cause a 500 error because that named location doesn't exist in the SSL server. 