### PR TITLE
Adding support for proxy timeouts

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -48,6 +48,13 @@ access_log	<%= node[:nginx][:log_dir] %>/access.log<%=" #{node[:nginx][:log_form
 
   server_names_hash_bucket_size <%= node[:nginx][:server_names_hash_bucket_size] %>;
 
+<% if node[:nginx][:proxy_read_timeout] -%>
+  proxy_read_timeout <%= node[:nginx][:proxy_read_timeout] %>;
+<% end -%>
+<% if node[:nginx][:proxy_send_timeout] -%>
+  proxy_send_timeout <%= node[:nginx][:proxy_send_timeout] %>;
+<% end -%>
+
   include <%= node[:nginx][:dir] %>/conf.d/*.conf;
   include <%= node[:nginx][:dir] %>/sites-enabled/*;
 }

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -19,6 +19,8 @@ describe file('/etc/nginx/nginx.conf') do
   its(:content) { should include 'use epoll' }
   its(:content) { should include 'worker_rlimit_nofile 4096' }
   its(:content) { should include 'gzip_types application/x-javascript application/xhtml+xml application/xml application/xml+rss text/css text/javascript text/plain text/xml application/json application/javascript;' }
+  its(:content) { should include 'proxy_read_timeout 60' }
+  its(:content) { should include 'proxy_send_timeout 60' }
 end
 
 describe file('/etc/nginx/shared_server.conf.d/maintenance.conf') do


### PR DESCRIPTION
Adding support to our nginx configuration template for the existing attributes.
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/nginx/attributes/nginx.rb#L67-L68
https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.4/nginx/attributes/nginx.rb#L61-L62

This is useful when your passenger app has extremely long requests Nginx serves them a gateway timeout.