### PR TITLE
Making status allowed sources to be flexible.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,8 @@ default[:nginx][:log_format] = {
 }
 default[:nginx][:log_format_name] = 'main'
 
+default[:nginx][:status][:access] = %w[127.0.0.1]
+
 # rubywrapper
 default[:ruby_wrapper][:install_path] = "/usr/local/bin/ruby-wrapper.sh"
 default[:ruby_wrapper][:ruby_binary] = "/usr/local/bin/ruby"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,7 @@ default[:nginx][:log_format] = {
 }
 default[:nginx][:log_format_name] = 'main'
 
-default[:nginx][:status][:access] = %w[127.0.0.1]
+default[:nginx][:status][:allow] = %w[127.0.0.1]
 
 # rubywrapper
 default[:ruby_wrapper][:install_path] = "/usr/local/bin/ruby-wrapper.sh"

--- a/providers/nginx_app.rb
+++ b/providers/nginx_app.rb
@@ -37,7 +37,8 @@ action :create do
         :ssl_port => deploy[:ssl_port] || 443,
         :ssl_support => deploy[:ssl_support] || false,
         :try_static_files => node[:nginx][:try_static_files],
-        :default_server => node[:nginx][:default_server]
+        :default_server => node[:nginx][:default_server],
+        :status => node[:nginx][:status]
     )
     if restart && ::File.exists?("#{node[:nginx][:dir]}/sites-enabled/#{application_name}")
       notifies :reload, "service[nginx]", :delayed

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -47,7 +47,9 @@ server {
   location /nginx_status {
     stub_status on;
     access_log off;
-    allow 127.0.0.1;
+    <% @status[:allow].each do |source| %>
+    allow <%= source %>;
+    <% end %>
     deny all;
   }
 


### PR DESCRIPTION
The nginx status route only allows localhost by default.  Moving this value to a customizable attribute to support more sources.  This is useful if you want to gather metrics from another server in your network.

http://nginx.org/en/docs/http/ngx_http_stub_status_module.html
http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
