### PR TITLE
adding support for Nginx send timeouts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ override[:nginx][:gzip_types] = (base_gzip_types + %w[application/json applicati
 # Custom configuration variables
 default[:nginx][:worker_rlimit_nofile] = nil
 default[:nginx][:connection_processing_method] = "epoll"
+default[:nginx][:send_timeout] = "60"
 
 # Custom Nginx package with passenger module
 default[:nginx][:custom_package][:package_location] = "/usr/src/rpm/RPMS/x86_64/"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ override[:nginx][:gzip_types] = (base_gzip_types + %w[application/json applicati
 # Custom configuration variables
 default[:nginx][:worker_rlimit_nofile] = nil
 default[:nginx][:connection_processing_method] = "epoll"
-default[:nginx][:send_timeout] = "60"
+default[:nginx][:send_timeout] = "60s"
 
 # Custom Nginx package with passenger module
 default[:nginx][:custom_package][:package_location] = "/usr/src/rpm/RPMS/x86_64/"

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -54,7 +54,9 @@ access_log	<%= node[:nginx][:log_dir] %>/access.log<%=" #{node[:nginx][:log_form
 <% if node[:nginx][:proxy_send_timeout] -%>
   proxy_send_timeout <%= node[:nginx][:proxy_send_timeout] %>;
 <% end -%>
-
+<% if node[:nginx][:send_timeout] -%>
+    send_timeout <%= node[:nginx][:send_timeout] %>;
+<% end -%>
   include <%= node[:nginx][:dir] %>/conf.d/*.conf;
   include <%= node[:nginx][:dir] %>/sites-enabled/*;
 }

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -55,7 +55,7 @@ access_log	<%= node[:nginx][:log_dir] %>/access.log<%=" #{node[:nginx][:log_form
   proxy_send_timeout <%= node[:nginx][:proxy_send_timeout] %>;
 <% end -%>
 <% if node[:nginx][:send_timeout] -%>
-    send_timeout <%= node[:nginx][:send_timeout] %>;
+  send_timeout <%= node[:nginx][:send_timeout] %>;
 <% end -%>
   include <%= node[:nginx][:dir] %>/conf.d/*.conf;
   include <%= node[:nginx][:dir] %>/sites-enabled/*;

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -21,7 +21,7 @@ describe file('/etc/nginx/nginx.conf') do
   its(:content) { should include 'gzip_types application/x-javascript application/xhtml+xml application/xml application/xml+rss text/css text/javascript text/plain text/xml application/json application/javascript;' }
   its(:content) { should include 'proxy_read_timeout 60' }
   its(:content) { should include 'proxy_send_timeout 60' }
-  its(:content) { should include 'send_timeout 60' }
+  its(:content) { should include 'send_timeout 60s' }
 end
 
 describe file('/etc/nginx/shared_server.conf.d/maintenance.conf') do

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -21,6 +21,7 @@ describe file('/etc/nginx/nginx.conf') do
   its(:content) { should include 'gzip_types application/x-javascript application/xhtml+xml application/xml application/xml+rss text/css text/javascript text/plain text/xml application/json application/javascript;' }
   its(:content) { should include 'proxy_read_timeout 60' }
   its(:content) { should include 'proxy_send_timeout 60' }
+  its(:content) { should include 'send_timeout 60' }
 end
 
 describe file('/etc/nginx/shared_server.conf.d/maintenance.conf') do


### PR DESCRIPTION
Adding support to our nginx configuration template for the existing attribute:

http://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout
