### PR TITLE
Add proxy-protocol support when needed

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,7 @@ override[:nginx][:gzip_types] = (base_gzip_types + %w[application/json applicati
 default[:nginx][:worker_rlimit_nofile] = nil
 default[:nginx][:connection_processing_method] = "epoll"
 default[:nginx][:send_timeout] = "60s"
+default[:nginx][:use_proxy_protocol] = false
 
 # Custom Nginx package with passenger module
 default[:nginx][:custom_package][:package_location] = "/usr/src/rpm/RPMS/x86_64/"
@@ -89,4 +90,3 @@ default[:passenger][:conf][:passenger_buffer_size] = '32k'
 default[:passenger][:conf][:passenger_user_switching] = nil
 default[:passenger][:conf][:passenger_default_user] = nil
 default[:passenger][:conf][:passenger_default_group] = nil
-

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen   <%= @http_port %><%= " default_server" if @default_server %><%= " proxy_protocol" if node[:nginx][:use_proxy_protocol] %>;
+  listen   <%= @http_port %><%= " default_server" if @default_server %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
@@ -19,8 +19,8 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
-    passenger_set_header HTTP_X_FORWARDED_FOR   <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$proxy_add_x_forwarded_for" %>;
-    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr" %>;
+    passenger_set_header HTTP_X_FORWARDED_FOR  $proxy_add_x_forwarded_for;
+    passenger_set_header HTTP_X_REAL_IP        $remote_addr;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
@@ -59,7 +59,7 @@ server {
 
 <% if @deploy[:ssl_support] %>
 server {
-  listen   <%= @ssl_port %><%= " default_server" if @default_server %><%= " proxy_protocol" if node[:nginx][:use_proxy_protocol] %>;
+  listen   <%= @ssl_port %><%= " default_server" if @default_server %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
@@ -91,8 +91,8 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
-    passenger_set_header HTTP_X_FORWARDED_FOR   <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$proxy_add_x_forwarded_for" %>;
-    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr" %>;
+    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_add_x_forwarded_for;
+    passenger_set_header HTTP_X_REAL_IP         $remote_addr;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
@@ -122,7 +122,7 @@ server {
 
 <% if @deploy[:use_proxy_protocol] %>
     server {
-    listen   <%= @proxy_protocol_port %><%= " default_server" if @default_server %> proxy_protocol
+    listen   <%= @proxy_protocol_port %><%= " default_server" if @default_server %> proxy_protocol;
     server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
     access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen   <%= @http_port %><%= " default_server" if @default_server %><%= " proxy-protocol" if node[:nginx][:use_proxy_protocol] %>;
+  listen   <%= @http_port %><%= " default_server" if @default_server %><%= " proxy_protocol" if node[:nginx][:use_proxy_protocol] %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
@@ -59,7 +59,7 @@ server {
 
 <% if @deploy[:ssl_support] %>
 server {
-  listen   <%= @ssl_port %><%= " default_server" if @default_server %><%= " proxy-protocol" if node[:nginx][:use_proxy_protocol] %>;
+  listen   <%= @ssl_port %><%= " default_server" if @default_server %><%= " proxy_protocol" if node[:nginx][:use_proxy_protocol] %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -19,8 +19,8 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
-    passenger_set_header HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
-    passenger_set_header HTTP_X_REAL_IP       $remote_addr;
+    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_add_x_forwarded_for;
+    passenger_set_header HTTP_X_REAL_IP         $remote_addr;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -119,3 +119,66 @@ server {
   include <%= node[:nginx][:dir] %>/ssl_server.conf.d/*.conf;
 }
 <% end %>
+
+<% if @deploy[:use_proxy_protocol] %>
+    server {
+    listen   <%= @proxy_protocol_port %><%= " default_server" if @default_server %> proxy_protocol
+    server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
+    access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
+
+    ssl on;
+    ssl_certificate /etc/nginx/ssl/<%= @deploy[:domains].first %>.crt;
+    ssl_certificate_key /etc/nginx/ssl/<%= @deploy[:domains].first %>.key;
+    <% if @deploy[:ssl_certificate_ca] -%>
+        ssl_client_certificate /etc/nginx/ssl/<%= @deploy[:domains].first %>.ca;
+    <% end -%>
+
+    <% @deploy.fetch(:nginx, {}).fetch(:extra_ssl_server_options, {}).each do |config_key, value| %>
+        <%= config_key %> <%= value %>;
+    <% end %>
+
+    root   <%= @deploy[:absolute_document_root] %>;
+
+
+    location / {
+    if ($maintenance) {
+    return 503;
+    break;
+    }
+    <% if @try_static_files %>
+        try_files  $uri $uri/index.html $uri.html @app_<%= @application_name %>_ssl;
+        }
+        location @app_<%= @application_name %>_ssl {
+    <% end %>
+    # Turn on the passenger Nginx helper for this location.
+    passenger_enabled on;
+
+    # These don't seem to work in stack, which is in the http {} block
+    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_protocol_addr
+    passenger_set_header HTTP_X_REAL_IP         $proxy_protocol_addr
+    passenger_set_header HTTP_HOST              $http_host;
+    passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
+    # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
+    passenger_set_header HTTP_X_REQUEST_START "t=${msec}";
+
+    # Rails 3.0 apps that use rack-ssl use SERVER_PORT to generate a https
+    # URL. Since internally nginx runs on a different port, the generated
+    # URL looked like this: https://host:81/ instead of https://host/
+    # By setting SERVER_PORT this is avoided.
+    passenger_set_header SERVER_PORT            443;
+
+    #
+    # Define the rack/rails application environment.
+    #
+    rack_env <%= @rails_env %>;
+    }
+
+    error_page 503 /maintenance.html;
+    location = /maintenance.html {
+    root <%= node[:nginx][:prefix_dir] %>/html;
+    }
+
+    include <%= node[:nginx][:dir] %>/shared_server.conf.d/*.conf;
+    include <%= node[:nginx][:dir] %>/ssl_server.conf.d/*.conf;
+    }
+<% end %>

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen   <%= @http_port %><%= " default_server" if @default_server %>;
+  listen   <%= @http_port %><%= " default_server" if @default_server %><%= " proxy-protocol" if node[:nginx][:use_proxy_protocol] %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
@@ -19,8 +19,8 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
-    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_add_x_forwarded_for;
-    passenger_set_header HTTP_X_REAL_IP         $remote_addr;
+    passenger_set_header HTTP_X_FORWARDED_FOR   <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$proxy_add_x_forwarded_for" %>;
+    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr;" %>;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
@@ -59,7 +59,7 @@ server {
 
 <% if @deploy[:ssl_support] %>
 server {
-  listen   <%= @ssl_port %><%= " default_server" if @default_server %>;
+  listen   <%= @ssl_port %><%= " default_server" if @default_server %><%= " proxy-protocol" if node[:nginx][:use_proxy_protocol] %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
@@ -91,8 +91,8 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
-    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_add_x_forwarded_for;
-    passenger_set_header HTTP_X_REAL_IP         $remote_addr;
+    passenger_set_header HTTP_X_FORWARDED_FOR   <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$proxy_add_x_forwarded_for" %>;
+    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr;" %>;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -20,7 +20,7 @@ server {
 
     # These don't seem to work in stack, which is in the http {} block
     passenger_set_header HTTP_X_FORWARDED_FOR   <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$proxy_add_x_forwarded_for" %>;
-    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr;" %>;
+    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr" %>;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
@@ -92,7 +92,7 @@ server {
 
     # These don't seem to work in stack, which is in the http {} block
     passenger_set_header HTTP_X_FORWARDED_FOR   <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$proxy_add_x_forwarded_for" %>;
-    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr;" %>;
+    passenger_set_header HTTP_X_REAL_IP         <%= node[:nginx][:use_proxy_protocol] ? "$proxy_protocol_addr" : "$remote_addr" %>;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -19,8 +19,8 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
-    passenger_set_header HTTP_X_FORWARDED_FOR  $proxy_add_x_forwarded_for;
-    passenger_set_header HTTP_X_REAL_IP        $remote_addr;
+    passenger_set_header HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+    passenger_set_header HTTP_X_REAL_IP       $remote_addr;
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx


### PR DESCRIPTION
Defaults to off. Uses incoming proxy-protocol addresses for headers when turned on.
