### PR TITLE
Update Nginx SSL configuration to increase security

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,11 @@ override[:nginx][:gzip_comp_level] = "8"
 base_gzip_types = node[:nginx][:gzip_types]
 override[:nginx][:gzip_types] = (base_gzip_types + %w[application/json application/javascript])
 
+# SSL configuration
+default[:nginx][:ssl_dir] = "#{node[:nginx][:dir]}/ssl"
+default[:nginx][:dh_key] = "#{node[:nginx][:ssl_dir]}/dhparam.pem"
+default[:nginx][:dh_key_bits] = 4096
+
 # Custom configuration variables
 default[:nginx][:worker_rlimit_nofile] = nil
 default[:nginx][:connection_processing_method] = "epoll"

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -99,6 +99,7 @@ server {
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
     passenger_set_header HTTP_X_REQUEST_START "t=${msec}";
+    passenger_set_header X-SSL-Protocol $ssl_protocol;
 
     # Rails 3.0 apps that use rack-ssl use SERVER_PORT to generate a https
     # URL. Since internally nginx runs on a different port, the generated

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -60,10 +60,12 @@ server {
 <% if @deploy[:ssl_support] %>
 server {
   listen   <%= @ssl_port %><%= " default_server" if @default_server %>;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
   ssl on;
+  ssl_dhparam <%= @dh_key %>;
   ssl_certificate /etc/nginx/ssl/<%= @deploy[:domains].first %>.crt;
   ssl_certificate_key /etc/nginx/ssl/<%= @deploy[:domains].first %>.key;
   <% if @deploy[:ssl_certificate_ca] -%>

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -94,10 +94,12 @@ server {
 
 server {
   listen   443;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   server_name  test-kitchen.sportngin.com #{`hostname | tr -d '\n'`};
   access_log  /var/log/nginx/test-kitchen.sportngin.com-ssl.access.log main;
 
   ssl on;
+  ssl_dhparam /etc/nginx/ssl/dhparam.pem;
   ssl_certificate /etc/nginx/ssl/test-kitchen.sportngin.com.crt;
   ssl_certificate_key /etc/nginx/ssl/test-kitchen.sportngin.com.key;
 

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -122,6 +122,7 @@ server {
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
     passenger_set_header HTTP_X_REQUEST_START "t=${msec}";
+    passenger_set_header X-SSL-Protocol $ssl_protocol;
 
     # Rails 3.0 apps that use rack-ssl use SERVER_PORT to generate a https
     # URL. Since internally nginx runs on a different port, the generated

--- a/test/integration/maintenance/serverspec/nginx_spec.rb
+++ b/test/integration/maintenance/serverspec/nginx_spec.rb
@@ -65,10 +65,12 @@ server {
 
 server {
   listen   443;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   server_name  test-kitchen.sportngin.com #{`hostname | tr -d '\n'`};
   access_log  /var/log/nginx/test-kitchen.sportngin.com-ssl.access.log main;
 
   ssl on;
+  ssl_dhparam /etc/nginx/ssl/dhparam.pem;
   ssl_certificate /etc/nginx/ssl/test-kitchen.sportngin.com.crt;
   ssl_certificate_key /etc/nginx/ssl/test-kitchen.sportngin.com.key;
 
@@ -91,6 +93,7 @@ server {
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
     passenger_set_header HTTP_X_REQUEST_START "t=${msec}";
+    passenger_set_header X-SSL-Protocol $ssl_protocol;
 
     # Rails 3.0 apps that use rack-ssl use SERVER_PORT to generate a https
     # URL. Since internally nginx runs on a different port, the generated

--- a/test/integration/multi_site_html_app/serverspec/nginx_spec.rb
+++ b/test/integration/multi_site_html_app/serverspec/nginx_spec.rb
@@ -97,10 +97,12 @@ server {
 
 server {
   listen   443 default_server;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   server_name  test-kitchen.sportngin.com #{`hostname | tr -d '\n'`};
   access_log  /var/log/nginx/test-kitchen.sportngin.com-ssl.access.log main;
 
   ssl on;
+  ssl_dhparam /etc/nginx/ssl/dhparam.pem;
   ssl_certificate /etc/nginx/ssl/test-kitchen.sportngin.com.crt;
   ssl_certificate_key /etc/nginx/ssl/test-kitchen.sportngin.com.key;
 
@@ -126,6 +128,7 @@ server {
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
     passenger_set_header HTTP_X_REQUEST_START "t=${msec}";
+    passenger_set_header X-SSL-Protocol $ssl_protocol;
 
     # Rails 3.0 apps that use rack-ssl use SERVER_PORT to generate a https
     # URL. Since internally nginx runs on a different port, the generated

--- a/test/integration/no_restart_on_deploy/serverspec/nginx_spec.rb
+++ b/test/integration/no_restart_on_deploy/serverspec/nginx_spec.rb
@@ -88,10 +88,12 @@ server {
 
 server {
   listen   443;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   server_name  test-kitchen.sportngin.com #{`hostname | tr -d '\n'`};
   access_log  /var/log/nginx/test-kitchen.sportngin.com-ssl.access.log main;
 
   ssl on;
+  ssl_dhparam /etc/nginx/ssl/dhparam.pem;
   ssl_certificate /etc/nginx/ssl/test-kitchen.sportngin.com.crt;
   ssl_certificate_key /etc/nginx/ssl/test-kitchen.sportngin.com.key;
 
@@ -114,6 +116,7 @@ server {
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
     passenger_set_header HTTP_X_REQUEST_START "t=${msec}";
+    passenger_set_header X-SSL-Protocol $ssl_protocol;
 
     # Rails 3.0 apps that use rack-ssl use SERVER_PORT to generate a https
     # URL. Since internally nginx runs on a different port, the generated


### PR DESCRIPTION
Description and Impact
----------------------
1. 4096-bit Diffie-Hellman key should be generated.
2. `X-SSL-PROTOCOL` header should be set.
3. HSTS should be enabled.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
