### PR TITLE
Turn HSTS off by default, allow it to be turned on with an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,7 @@ base_gzip_types = node[:nginx][:gzip_types]
 override[:nginx][:gzip_types] = (base_gzip_types + %w[application/json application/javascript])
 
 # SSL configuration
+default[:nginx][:use_hsts] = false
 default[:nginx][:ssl_dir] = "#{node[:nginx][:dir]}/ssl"
 default[:nginx][:dh_key] = "#{node[:nginx][:ssl_dir]}/dhparam.pem"
 default[:nginx][:dh_key_bits] = 4096
@@ -99,4 +100,3 @@ default[:passenger][:conf][:passenger_buffer_size] = '32k'
 default[:passenger][:conf][:passenger_user_switching] = nil
 default[:passenger][:conf][:passenger_default_user] = nil
 default[:passenger][:conf][:passenger_default_group] = nil
-

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -61,7 +61,7 @@ server {
 server {
   listen   <%= @ssl_port %><%= " default_server" if @default_server %>;
   <% if node[:nginx][:use_hsts] %>
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header Strict-Transport-Security "max-age=31536000;"
   <% end -%>
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -60,7 +60,9 @@ server {
 <% if @deploy[:ssl_support] %>
 server {
   listen   <%= @ssl_port %><%= " default_server" if @default_server %>;
+  <% if node[:nginx][:use_hsts] %>
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  <% end -%>
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>-ssl.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -94,7 +94,6 @@ server {
 
 server {
   listen   443;
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   server_name  test-kitchen.sportngin.com #{`hostname | tr -d '\n'`};
   access_log  /var/log/nginx/test-kitchen.sportngin.com-ssl.access.log main;
 


### PR DESCRIPTION
Description and Impact
----------------------
See title

Deploy Plan
-----------
Update cookbook dependencies for passenger apps and set the attribute where HSTS is required.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
Make sure the config line isn't in place when you don't want it to be.