### PR TITLE
Allow for redirecting connections using Weak TLS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ default[:nginx][:use_hsts] = false
 default[:nginx][:ssl_dir] = "#{node[:nginx][:dir]}/ssl"
 default[:nginx][:dh_key] = "#{node[:nginx][:ssl_dir]}/dhparam.pem"
 default[:nginx][:dh_key_bits] = 4096
+default[:nginx][:deprecate_weak_tls] = false
 
 # Custom configuration variables
 default[:nginx][:worker_rlimit_nofile] = nil

--- a/files/default/deprecate-weak-tls.conf
+++ b/files/default/deprecate-weak-tls.conf
@@ -1,0 +1,3 @@
+if ($ssl_protocol ~ "TLSv1$") {
+    rewrite ^(.*)$ http://www.$host/unsupported_browser;
+}

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -10,7 +10,7 @@ cookbook_file "#{node[:nginx][:prefix_dir]}/html/maintenance.html" do
 end
 include_recipe "opsworks-passenger::maintenance"
 
-cookbook_file "#{node[:nginx][:dir]}/shared_server.conf.d/deprecate-weak-tls.conf" do
+cookbook_file "#{node[:nginx][:dir]}/ssl_server.conf.d/deprecate-weak-tls.conf" do
   source "deprecate-weak-tls.conf"
   group "root"
   owner "root"

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -10,6 +10,13 @@ cookbook_file "#{node[:nginx][:prefix_dir]}/html/maintenance.html" do
 end
 include_recipe "opsworks-passenger::maintenance"
 
+cookbook_file "#{node[:nginx][:dir]}/shared_server.conf.d/deprecate-weak-tls.conf" do
+  source "deprecate-weak-tls.conf"
+  group "root"
+  owner "root"
+  mode 0644
+end if node[:nginx][:deprecate_weak_tls]
+
 template node[:ruby_wrapper][:install_path] do
   source "ruby-wrapper.sh.erb"
   owner "root"


### PR DESCRIPTION
Description and Impact
----------------------
When enabled, this redirects all connections using TLSv1 to `/unsupported_browser` instructing users to update their browsers.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
Using Firefox:
 1. Go to: `about:config`
 1. Set `security.tls.version.max` to `1`
 1. Go to https://omgha.sportngin.com and make sure you get redirected to https://omgha.sportngin.com/unsuported_browser

