### PR TITLE
Add flag for nginx to enable proxy protocol

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,6 +45,9 @@ default[:nginx][:log_format_name] = 'main'
 
 default[:nginx][:status][:allow] = %w[127.0.0.1]
 
+# By default, nginx is not configured to accept proxy protocol
+default[:nginx][:proxy_protocol_enable] = false
+
 # rubywrapper
 default[:ruby_wrapper][:install_path] = "/usr/local/bin/ruby-wrapper.sh"
 default[:ruby_wrapper][:ruby_binary] = "/usr/local/bin/ruby"

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -53,10 +53,6 @@ server {
     deny all;
   }
 
-  <% if node[:nginx][:proxy_protocol_enable] %>
-  real_ip_header proxy_protocol;
-  <% end %>
-
   include <%= node[:nginx][:dir] %>/shared_server.conf.d/*.conf;
   include <%= node[:nginx][:dir] %>/http_server.conf.d/*.conf;
 }

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen   <%= @http_port %><%= " default_server" if @default_server %><%= " proxy_protocol" if node[:nginx][:proxy_protocol_enable] %>;
+  listen   <%= @http_port %><%= " default_server" if @default_server %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
@@ -19,13 +19,8 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
-    <% if node[:nginx][:proxy_protocol_enable] %>
-    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_protocol_addr;
-    passenger_set_header HTTP_X_REAL_IP         $proxy_protocol_addr;
-    <% else %>
     passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_add_x_forwarded_for;
     passenger_set_header HTTP_X_REAL_IP         $remote_addr;
-    <% end %>
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen   <%= @http_port %><%= " default_server" if @default_server %>;
+  listen   <%= @http_port %><%= " default_server" if @default_server %><%= " proxy_protocol" if node[:nginx][:proxy_protocol_enable] %>;
   server_name  <%= @deploy[:domains].join(" ") %> <%= node[:hostname] %>;
   access_log  <%= node[:nginx][:log_dir] %>/<%= @deploy[:domains].first %>.access.log<%=" #{node[:nginx][:log_format_name]}" unless node[:nginx][:log_format_name].nil? %>;
 
@@ -19,8 +19,13 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
+    <% if node[:nginx][:proxy_protocol_enable] %>
+    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_protocol_addr;
+    passenger_set_header HTTP_X_REAL_IP         $proxy_protocol_addr;
+    <% else %>
     passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_add_x_forwarded_for;
     passenger_set_header HTTP_X_REAL_IP         $remote_addr;
+    <% end %>
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
@@ -53,13 +58,17 @@ server {
     deny all;
   }
 
+  <% if node[:nginx][:proxy_protocol_enable] %>
+  real_ip_header proxy_protocol;
+  <% end %>
+
   include <%= node[:nginx][:dir] %>/shared_server.conf.d/*.conf;
   include <%= node[:nginx][:dir] %>/http_server.conf.d/*.conf;
 }
 
 <% if @deploy[:ssl_support] %>
 server {
-  listen   <%= @ssl_port %><%= " default_server" if @default_server %>;
+  listen   <%= @ssl_port %><%= " default_server" if @default_server %><%= " proxy_protocol" if node[:nginx][:proxy_protocol_enable] %>;
   <% if node[:nginx][:use_hsts] %>
   add_header Strict-Transport-Security "max-age=31536000;"
   <% end -%>
@@ -95,8 +104,13 @@ server {
     passenger_enabled on;
 
     # These don't seem to work in stack, which is in the http {} block
+    <% if node[:nginx][:proxy_protocol_enable] %>
+    passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_protocol_addr;
+    passenger_set_header HTTP_X_REAL_IP         $proxy_protocol_addr;
+    <% else %>
     passenger_set_header HTTP_X_FORWARDED_FOR   $proxy_add_x_forwarded_for;
     passenger_set_header HTTP_X_REAL_IP         $remote_addr;
+    <% end %>
     passenger_set_header HTTP_HOST              $http_host;
     passenger_set_header HTTP_X_FORWARDED_PROTO $scheme;
     # https://docs.newrelic.com/docs/apm/other-features/request-queueing/request-queue-server-configuration-examples#nginx
@@ -119,6 +133,10 @@ server {
   location = /maintenance.html {
     root <%= node[:nginx][:prefix_dir] %>/html;
   }
+
+  <% if node[:nginx][:proxy_protocol_enable] %>
+  real_ip_header proxy_protocol;
+  <% end %>
 
   include <%= node[:nginx][:dir] %>/shared_server.conf.d/*.conf;
   include <%= node[:nginx][:dir] %>/ssl_server.conf.d/*.conf;


### PR DESCRIPTION
What
----------------------
Nginx is configured to accept proxy-protocol when node[:nginx][:proxy_protocol_enable] is on.

Why
----------------------
Currently, nginx is not configured to use `proxy-protocol`. When a load balancer is used with nginx, nginx can only see the private ip address of the load balancer not the real client ip (assuming `https` is enabled). Using `proxy-protocol` will allow nginx to read the real client ips of requests.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/

QA Plan
-------
- [x] nginx should be able to accept proxy protocol 
